### PR TITLE
Issue#3 context not in error map

### DIFF
--- a/src/hvl/projectparmorel/exceptions/UnsupportedErrorException.java
+++ b/src/hvl/projectparmorel/exceptions/UnsupportedErrorException.java
@@ -1,0 +1,17 @@
+package hvl.projectparmorel.exceptions;
+
+public class UnsupportedErrorException extends Exception{
+
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 1L;
+
+	public UnsupportedErrorException() {
+		super();
+	}
+	
+	public UnsupportedErrorException(String msg) {
+		super(msg);
+	}
+}

--- a/src/hvl/projectparmorel/knowledge/Knowledge.java
+++ b/src/hvl/projectparmorel/knowledge/Knowledge.java
@@ -62,7 +62,7 @@ public class Knowledge {
 			DocumentBuilderFactory documentFactory = DocumentBuilderFactory.newInstance();
 			DocumentBuilder documentBuilder = documentFactory.newDocumentBuilder();
 			Document document = documentBuilder.newDocument();
-			logger.info("document created");
+			logger.info("document prepared");
 
 			Element root = document.createElement("knowledge");
 			document.appendChild(root);
@@ -72,9 +72,10 @@ public class Knowledge {
 			TransformerFactory transformerFactory = TransformerFactory.newInstance();
 			Transformer transformer = transformerFactory.newTransformer();
 			DOMSource domSource = new DOMSource(document);
-			StreamResult streamResult = new StreamResult(new File(knowledgeFileName));
+			File file = new File(knowledgeFileName);
+			StreamResult streamResult = new StreamResult(file);
 			transformer.transform(domSource, streamResult);
-			logger.info("Saving completed");
+			logger.info("Saving completed to " + file.getAbsolutePath());
 		} catch (ParserConfigurationException pce) {
 			pce.printStackTrace();
 		} catch (TransformerException tfe) {
@@ -90,7 +91,7 @@ public class Knowledge {
 		try {
 			logger.info("Loading initialized");
 			File fXmlFile = new File(knowledgeFileName);
-			logger.info("File found");
+			logger.info("File created: " + fXmlFile.getAbsolutePath());
 			DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
 			DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
 			Document doc = dBuilder.parse(fXmlFile);

--- a/src/hvl/projectparmorel/knowledge/Knowledge.java
+++ b/src/hvl/projectparmorel/knowledge/Knowledge.java
@@ -19,6 +19,8 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.xml.sax.SAXException;
 
+import hvl.projectparmorel.exceptions.UnsupportedErrorException;
+
 /**
  * Represents the algorithms knowledge.
  * 
@@ -48,9 +50,15 @@ public class Knowledge {
 	 * 
 	 * @param errorCode
 	 * @return the action for the specified error code with the highest weight.
+	 * @throws UnsupportedErrorException if the error code is not in the Q-table
 	 */
-	public Action getOptimalActionForErrorCode(Integer errorCode) {
-		return qTable.getOptimalActionForErrorCode(errorCode);
+	public Action getOptimalActionForErrorCode(Integer errorCode) throws UnsupportedErrorException {
+		if(qTable.containsErrorCode(errorCode)) {
+			return qTable.getOptimalActionForErrorCode(errorCode);
+		} else {
+			logger.warning("Error code " + errorCode + " is not in the Q-table.");
+			throw new UnsupportedErrorException("The error code " + errorCode + " was not in the QTable.");
+		}
 	}
 
 	/**

--- a/src/hvl/projectparmorel/ml/ErrorExtractor.java
+++ b/src/hvl/projectparmorel/ml/ErrorExtractor.java
@@ -2,7 +2,9 @@ package hvl.projectparmorel.ml;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.logging.Logger;
 
 import org.eclipse.emf.common.util.Diagnostic;
 import org.eclipse.emf.ecore.EObject;
@@ -14,6 +16,9 @@ import org.eclipse.emf.ecore.util.Diagnostician;
 
 public class ErrorExtractor {
 
+	public static List<Integer> unsuportedErrorCodes = new ArrayList<>(Arrays.asList(4, 6));
+	private static Logger logger = Logger.getGlobal();
+	
 	/**
 	 * Extracts the errors from the provided model.
 	 * 
@@ -28,7 +33,11 @@ public class ErrorExtractor {
 			for (Diagnostic child : diagnostic.getChildren()) {
 				Error error = getErrorFor(child);
 				if (error != null) {
-					errors.add(error);
+					if(unsuportedErrorCodes.contains(error.getCode())){
+						logger.warning("Encounteded unsupported error " + error.getCode() + ". Message: " + error.getMessage() + ". Skipping error.");
+					} else {
+						errors.add(error);
+					}
 				}
 			}
 		}

--- a/src/hvl/projectparmorel/ml/ErrorExtractor.java
+++ b/src/hvl/projectparmorel/ml/ErrorExtractor.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.emf.common.util.Diagnostic;
+import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.impl.EPackageImpl;
 import org.eclipse.emf.ecore.impl.EReferenceImpl;
@@ -41,7 +42,8 @@ public class ErrorExtractor {
 	 * @return the diagnostic for the model
 	 */
 	private static Diagnostic validateMode(Resource model) {
-		return Diagnostician.INSTANCE.validate(model.getContents().get(0));
+		EObject object = model.getContents().get(0);
+		return Diagnostician.INSTANCE.validate(object);
 	}
 
 	/**

--- a/src/hvl/projectparmorel/ml/ModelFixer.java
+++ b/src/hvl/projectparmorel/ml/ModelFixer.java
@@ -1,0 +1,34 @@
+package hvl.projectparmorel.ml;
+
+import java.util.List;
+
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.resource.Resource;
+
+public interface ModelFixer {
+	
+	/**
+	 * Sets the user preferences used in the algorithm.
+	 * 
+	 * @param preferences
+	 */
+	public void setPreferences(List<Integer> preferences);
+
+	/**
+	 * Fixes the model provided as attribute, and stores the repaired model in the uri-location.
+	 * @param model
+	 * @param ur
+	 * @return the optimal sequence of actions
+	 */
+	public Sequence fixModel(Resource model, URI uri);
+
+	/**
+	 * Gets the model specified by the uri
+	 * 
+	 * @param uri
+	 * @return the coresponding model
+	 */
+	public Resource getModel(URI uri);
+
+	
+}

--- a/src/hvl/projectparmorel/ml/ModelFixer.java
+++ b/src/hvl/projectparmorel/ml/ModelFixer.java
@@ -6,13 +6,6 @@ import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.resource.Resource;
 
 public interface ModelFixer {
-	
-	/**
-	 * Sets the user preferences used in the algorithm.
-	 * 
-	 * @param preferences
-	 */
-	public void setPreferences(List<Integer> preferences);
 
 	/**
 	 * Fixes the model provided as attribute, and stores the repaired model in the uri-location.
@@ -29,7 +22,7 @@ public interface ModelFixer {
 	 * @return the coresponding model
 	 */
 	public Resource getModel(URI uri);
-
+  
 	/**
 	 * Checks that there exists error in the model
 	 * 
@@ -38,5 +31,19 @@ public interface ModelFixer {
 	 */
 	public boolean modelIsBroken(Resource model);
 
-	
+	/**
+	 * Copies the model passed as a parameter
+	 * 
+	 * @param model
+	 * @param uri, the Uniform Resource Identifier for the copy
+	 * @return a copy
+	 */
+	public Resource copy(Resource myMetaModel, URI uri);
+
+	/**
+	 * Sets the user preferences used in the algorithm.
+	 * 
+	 * @param preferences
+	 */
+	public void setPreferences(List<Integer> preferences);
 }

--- a/src/hvl/projectparmorel/ml/ModelFixer.java
+++ b/src/hvl/projectparmorel/ml/ModelFixer.java
@@ -30,5 +30,13 @@ public interface ModelFixer {
 	 */
 	public Resource getModel(URI uri);
 
+	/**
+	 * Checks that there exists error in the model
+	 * 
+	 * @param model
+	 * @return true if errors exist in the model, false otherwise
+	 */
+	public boolean modelIsBroken(Resource model);
+
 	
 }

--- a/src/hvl/projectparmorel/ml/QLearning.java
+++ b/src/hvl/projectparmorel/ml/QLearning.java
@@ -98,7 +98,7 @@ public class QLearning {
 	/**
 	 * Saves the knowledge
 	 */
-	public void saveKnowledge() {
+	private void saveKnowledge() {
 		knowledge.save();
 	}
 
@@ -109,7 +109,7 @@ public class QLearning {
 	 * This also reduces the number of episodes and the chance
 	 * for taking random actions. More previous knowledge reduces the need for many episodes and randomness.
 	 */
-	public void loadKnowledge() {
+	private void loadKnowledge() {
 		boolean success = knowledge.load();
 		if (success) {
 			knowledge.clearWeights();

--- a/src/hvl/projectparmorel/ml/QModelFixer.java
+++ b/src/hvl/projectparmorel/ml/QModelFixer.java
@@ -88,10 +88,7 @@ public class QModelFixer implements ModelFixer {
 		return resourceSet;
 	}
 
-	public List<Integer> getPreferences() {
-		return rewardCalculator.getPreferences();
-	}
-
+	@Override
 	public void setPreferences(List<Integer> preferences) {
 		rewardCalculator = new RewardCalculator(knowledge, preferences);
 		modelProcesser = new ModelProcesser(resourceSet, knowledge, rewardCalculator);
@@ -138,7 +135,7 @@ public class QModelFixer implements ModelFixer {
 
 	@Override
 	public Sequence fixModel(Resource model, URI uri) {
-		logger.info("Running with preferences " + getPreferences().toString());
+		logger.info("Running with preferences " + rewardCalculator.getPreferences().toString());
 		
 		this.uri = uri;
 		resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("ecore",
@@ -323,7 +320,8 @@ public class QModelFixer implements ModelFixer {
 	 * @param       uri, the Uniform Resource Identifier for the copy
 	 * @return a copy
 	 */
-	private Resource copy(Resource model, URI uri) {
+	@Override
+	public Resource copy(Resource model, URI uri) {
 		Resource modelCopy = resourceSet.createResource(uri);
 		modelCopy.getContents().add(EcoreUtil.copy(model.getContents().get(0)));
 		return modelCopy;

--- a/src/hvl/projectparmorel/ml/QModelFixer.java
+++ b/src/hvl/projectparmorel/ml/QModelFixer.java
@@ -138,6 +138,8 @@ public class QModelFixer implements ModelFixer {
 
 	@Override
 	public Sequence fixModel(Resource model, URI uri) {
+		logger.info("Running with preferences " + getPreferences().toString());
+		
 		this.uri = uri;
 		resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("ecore",
 				new EcoreResourceFactoryImpl());

--- a/src/hvl/projectparmorel/ml/QModelFixer.java
+++ b/src/hvl/projectparmorel/ml/QModelFixer.java
@@ -13,17 +13,19 @@ import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.emf.ecore.xmi.impl.EcoreResourceFactoryImpl;
 
 import hvl.projectparmorel.knowledge.Action;
-import hvl.projectparmorel.knowledge.QTable;
 import hvl.projectparmorel.knowledge.Knowledge;
+import hvl.projectparmorel.knowledge.QTable;
 import hvl.projectparmorel.reward.RewardCalculator;
 
 /**
+ * A model fixer that uses QLearning.
+ * 
  * Western Norway University of Applied Sciences Bergen, Norway
  * 
  * @author Angela Barriga Rodriguez abar@hvl.no
  * @author Magnus Marthinsen
  */
-public class QLearning {
+public class QModelFixer implements ModelFixer {
 	private final double MIN_ALPHA = 0.06; // Learning rate
 	private final double GAMMA = 1.0; // Eagerness - 0 looks in the near future, 1 looks in the distant future
 	private final int MAX_EPISODE_STEPS = 20;
@@ -50,7 +52,7 @@ public class QLearning {
 	private ResourceSet resourceSet;
 	private RewardCalculator rewardCalculator;
 
-	public QLearning() {
+	public QModelFixer() {
 		resourceSet = new ResourceSetImpl();
 		resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("ecore",
 				new EcoreResourceFactoryImpl());
@@ -68,7 +70,7 @@ public class QLearning {
 		loadKnowledge();
 	}
 
-	public QLearning(List<Integer> preferences) {
+	public QModelFixer(List<Integer> preferences) {
 		this();
 		rewardCalculator = new RewardCalculator(knowledge, preferences);
 		modelProcesser = new ModelProcesser(resourceSet, knowledge, rewardCalculator);
@@ -134,13 +136,7 @@ public class QLearning {
 		}
 	}
 
-	/**
-	 * Attempts to fix the model
-	 * 
-	 * @param model
-	 * @param uri
-	 * @return the best possible sequence
-	 */
+	@Override
 	public Sequence fixModel(Resource model, URI uri) {
 		this.uri = uri;
 		resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("ecore",
@@ -397,4 +393,10 @@ public class QLearning {
 		}
 		return maxS;
 	}
+
+	@Override
+	public Resource getModel(URI uri) {
+		return resourceSet.getResource(uri, true);
+	}
+
 }

--- a/src/hvl/projectparmorel/ml/QModelFixer.java
+++ b/src/hvl/projectparmorel/ml/QModelFixer.java
@@ -399,4 +399,10 @@ public class QModelFixer implements ModelFixer {
 		return resourceSet.getResource(uri, true);
 	}
 
+	@Override
+	public boolean modelIsBroken(Resource model) {
+		List<Error> errors = ErrorExtractor.extractErrorsFrom(model);
+		return !errors.isEmpty();
+	}
+
 }

--- a/src/hvl/projectparmorel/ml/QModelFixer.java
+++ b/src/hvl/projectparmorel/ml/QModelFixer.java
@@ -5,7 +5,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
 
+import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
@@ -160,7 +162,8 @@ public class QModelFixer implements ModelFixer {
 
 			// RESET initial model and extract actions + errors
 			modelCopy.getContents().clear();
-			modelCopy.getContents().add(EcoreUtil.copy(model.getContents().get(0)));
+			EObject content = model.getContents().get(0);
+			modelCopy.getContents().add(EcoreUtil.copy(content));
 			errorsToFix.clear();
 			errorsToFix.addAll(originalErrors);
 			episode++;
@@ -324,7 +327,8 @@ public class QModelFixer implements ModelFixer {
 	public Resource copy(Resource model, URI uri) {
 		Resource modelCopy = resourceSet.createResource(uri);
 //		modelCopy.getContents().add(EcoreUtil.copy(model.getContents().get(0)));
-		modelCopy.getContents().addAll(EcoreUtil.copyAll(model.getContents()));
+		EList<EObject> contents = model.getContents();
+		modelCopy.getContents().addAll(EcoreUtil.copyAll(contents));
 		return modelCopy;
 	}
 

--- a/src/hvl/projectparmorel/ml/QModelFixer.java
+++ b/src/hvl/projectparmorel/ml/QModelFixer.java
@@ -323,7 +323,8 @@ public class QModelFixer implements ModelFixer {
 	@Override
 	public Resource copy(Resource model, URI uri) {
 		Resource modelCopy = resourceSet.createResource(uri);
-		modelCopy.getContents().add(EcoreUtil.copy(model.getContents().get(0)));
+//		modelCopy.getContents().add(EcoreUtil.copy(model.getContents().get(0)));
+		modelCopy.getContents().addAll(EcoreUtil.copyAll(model.getContents()));
 		return modelCopy;
 	}
 

--- a/src/hvl/projectparmorel/ml/QModelFixer.java
+++ b/src/hvl/projectparmorel/ml/QModelFixer.java
@@ -2,7 +2,6 @@ package hvl.projectparmorel.ml;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Logger;
 
@@ -45,7 +44,6 @@ public class QModelFixer implements ModelFixer {
 
 	private List<Error> errorsToFix;
 	private int discardedSequences;
-	private static List<Integer> unsuportedErrorCodes = new ArrayList<>(Arrays.asList(4, 6));
 	
 	private Logger logger = Logger.getGlobal();
 
@@ -219,7 +217,7 @@ public class QModelFixer implements ModelFixer {
 		int step = 0;
 
 		while (step < MAX_EPISODE_STEPS) {
-			while(!errorsToFix.isEmpty() && unsuportedErrorCodes.contains(errorsToFix.get(0).getCode())) {
+			while(!errorsToFix.isEmpty() && ErrorExtractor.unsuportedErrorCodes.contains(errorsToFix.get(0).getCode())) {
 				logger.warning("UNSUPORTED ERROR CODE: " + errorsToFix.get(0).getCode() + "\nMessage: " + errorsToFix.get(0).getMessage());
 				errorsToFix.remove(0);
 			}

--- a/src/hvl/projectparmorel/ml/QModelFixer.java
+++ b/src/hvl/projectparmorel/ml/QModelFixer.java
@@ -268,10 +268,7 @@ public class QModelFixer implements ModelFixer {
 		double alpha = ALPHAS[episode];
 
 		errorsToFix.clear();
-		errorsToFix = modelProcesser.tryApplyAction(currentErrorToFix, action, modelCopy, action.getHierarchy()); // removed
-																													// subHirerarchy
-																													// -
-																													// effect?
+		errorsToFix = modelProcesser.tryApplyAction(currentErrorToFix, action, modelCopy, action.getHierarchy());
 		reward = rewardCalculator.calculateRewardFor(currentErrorToFix, action);
 		// Insert stuff into sequence
 		sequence.setId(episode);


### PR DESCRIPTION
Ignoring errors that does not repair themselves.

Still don't understand why more errors display when launching from the plugin, but maybe it is something that Eclipse does when processing the models?

This pull request solves https://github.com/MagMar94/ParmorelEclipsePlugin/issues/3
